### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,7 @@
     "mail": "andychilton@gmail.com"
   },
   "homepage": "https://github.com/chilts/mongodb-lock",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://chilts.mit-license.org/2015/"
-    }
-  ],
+  "license": "MIT",
   "keywords": [
     "mongodb",
     "lock"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
