### PR TITLE
Add support for 2.x.x MongoDB clients

### DIFF
--- a/mongodb-lock.js
+++ b/mongodb-lock.js
@@ -88,8 +88,7 @@ Lock.prototype.acquire = function(callback) {
         return callback(err)
       }
 
-      var doc = docs[0]
-      callback(null, doc.code)
+      callback(null, docs.ops ? docs.ops[0].code : docs[0].code)
     })
   })
 }
@@ -114,7 +113,11 @@ Lock.prototype.release = function release(code, callback) {
   self.col.findAndModify(q1, undefined /* sort order */, u1, function(err, oldDoc) {
     if (err) return callback(err)
 
-    if ( !oldDoc ) {
+    if(oldDoc && oldDoc.hasOwnProperty('value') && !oldDoc.value) {
+      return callback(null, false);
+    }
+
+    if (!oldDoc) {
       // there was nothing to unlock
       return callback(null, false)
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-lock",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Locks which uses MongoDB's atomic operations.",
   "main": "mongodb-lock.js",
   "scripts": {


### PR DESCRIPTION
Currently mongodb-lock does not support MongoDB clients that are not 1.x.x
This adds backwards compatible changes to support clients above version 1.
Only a few minor changes were made to support this.