### PR TITLE
Add option to remove expired locks instead of modify them

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ var sendInvoices = mongoDbLock(db, 'locks', 'send-invoices')
 
 ## Options ##
 
-Currently there is only the option of the timeout. Currently the default is 30 seconds, but you can change it (in milliseconds):
+Currently there are two options: `timeout` and `removeExpired`
+
+### timeout ###
+Currently the default is 30 seconds, but you can change it (in milliseconds):
 
 ```js
 // lock for 60 seconds
@@ -90,6 +93,13 @@ uploadFiles.lock(function(err, code) {
   // locked for 60s
 })
 ```
+
+### removeExpired
+Currently the default value is `false`.
+
+When set to `true` this will remove expired lock records from MongoDB instead 
+of modifying them.
+
 
 ### 0.2.0 (2015-04-17) ###
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongodb-lock",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Locks which uses MongoDB's atomic operations.",
   "main": "mongodb-lock.js",
   "scripts": {


### PR DESCRIPTION
Currenly when a lock is expired its record in MongoDB is modified
to include information about its expiry, along with changing its
name.

There may be cases where the end user will not want this to be the
case. For example, when trying to reduce the amount of data stored
in the collection itself when performing many `acquire` and `release`
actions.

This adds an option to the lock options Object called `removeExpired`.
When this is set to true, instead of performing a `findAndModify` on
the collection a `findAndRemove` is invoked instead.

This is compatible with both 1.X.X and 2.X.X streams of the MongoDB
client.

Tests have been added to test the current behaviour remains the default
and that the `removeExpired` option actually results in these records
being removed.